### PR TITLE
Crea clase Buffer para las búsquedas recientes

### DIFF
--- a/kindleBueno.js
+++ b/kindleBueno.js
@@ -122,7 +122,7 @@ class Kindle {
   }
 
   get recentSearches() {
-    return this._recentSearches;
+    return this._recentSearches.buffer;
   }
 }
 

--- a/kindleBueno.js
+++ b/kindleBueno.js
@@ -6,7 +6,7 @@ class Kindle {
     this._next = null;
     this._last = null;
     this._library = [];
-    this._recentSearches = [];
+    this._recentSearches = new Buffer(5);
   }
 
   add(eBook) {

--- a/kindleBueno.js
+++ b/kindleBueno.js
@@ -180,12 +180,11 @@ class Search {
 class Buffer {
   constructor(capacity) {
     this.buffer = new Array(capacity);
-    this.capacity = capacity;
     this.next = 0;
   }
 
   addToBuffer(data) {
-    if (this.next < this.capacity) {
+    if (this.next < this.buffer.length) {
       this.buffer[this.next] = data;
       this.next++;
     } else {

--- a/kindleBueno.js
+++ b/kindleBueno.js
@@ -173,8 +173,7 @@ class Search {
   }
 
   _updateRecentSearches(kindle, searchKeywords) {
-    kindle._recentSearches.push(searchKeywords);
-    if (kindle._recentSearches.length > 5) kindle._recentSearches.shift();
+    kindle._recentSearches.addToBuffer(searchKeywords);
   }
 }
 

--- a/kindleBueno.js
+++ b/kindleBueno.js
@@ -105,7 +105,7 @@ class Kindle {
   }
 
   filterBy(criteria) {}
-    
+
   sortBy(criteria) {
     return [...this.library]._sortCriteria(criteria);
   }
@@ -149,12 +149,16 @@ class Search {
 
   search(kindle, keywords) {
     const searchKeywords = this._cleanKeywords(keywords);
-    
-    const result = kindle.library.filter(ebook=> this._titleOrAuthorMatch(ebook, searchKeywords));
+
+    const result = kindle.library.filter(ebook =>
+      this._titleOrAuthorMatch(ebook, searchKeywords)
+    );
 
     this._updateRecentSearches(kindle, searchKeywords);
 
-    return result.length > 0 ? result : console.log("There are no results found in your library");
+    return result.length > 0
+      ? result
+      : console.log("There are no results found in your library");
   }
 
   _cleanKeywords(keywords) {
@@ -162,12 +166,32 @@ class Search {
   }
 
   _titleOrAuthorMatch(ebook, searchKeywords) {
-    return ebook.title.toLowerCase().includes(searchKeywords) || ebook.author.toLowerCase().includes(searchKeywords);
+    return (
+      ebook.title.toLowerCase().includes(searchKeywords) ||
+      ebook.author.toLowerCase().includes(searchKeywords)
+    );
   }
 
   _updateRecentSearches(kindle, searchKeywords) {
     kindle._recentSearches.push(searchKeywords);
-    if (kindle._recentSearches.length > 5)
-      kindle._recentSearches.shift();
+    if (kindle._recentSearches.length > 5) kindle._recentSearches.shift();
+  }
+}
+
+class Buffer {
+  constructor(capacity) {
+    this.buffer = new Array(capacity);
+    this.capacity = capacity;
+    this.next = 0;
+  }
+
+  addToBuffer(data) {
+    if (this.next < this.capacity) {
+      this.buffer[this.next] = data;
+      this.next++;
+    } else {
+      this.buffer[0] = data;
+      this.next = 1;
+    }
   }
 }


### PR DESCRIPTION
Avancé con un buffer rudimentario para las búsquedas (#28).
- Creé la clase Buffer. Tiene tres propiedades:
1. `buffer`: un array con un tamaño fijo que se le pasa en el constructor y en el que se van a ir agregando las búsquedas.
2. `capacity`: es el tamaño del buffer (el length del array).
3. `next` (no sé si es el mejor nombre): indica dónde va a ubicarse el próximo elemento que se agregue.

y un método:
`addToBuffer`: evalúa si `next` es menor que `capacity`, si es así, agrega lo que se le pase como parámetro en el índice `next` e incrementa `next` en 1. Si `next` no es menor que `capacity` (el índice no existiría en el array) agrega el elemento en el índice 0 y `next` pasa a ser 1.
- Modifiqué el método `updateRecentSearches` (para que use `addToBuffer`), el getter `recentSearches` (para que devuelva la propiedad buffer, es decir, el array con las búsquedas) y la propiedad `_recentSearches` del Kindle (para que sea un objeto de la clase Buffer).